### PR TITLE
explicitly convert different int types to avoid warnings in 64 bit

### DIFF
--- a/usbdmx.c
+++ b/usbdmx.c
@@ -66,7 +66,7 @@ typedef struct  {
 void wserial_to_serial(const wchar_t * s1, char * s2) {
     int i;
     for(i=0;i<16;++i) {
-        s2[i] = s1[i];
+        s2[i] = (char)s1[i];
     }
 }
 void wserial_from_serial(wchar_t * s1, const char * s2) {
@@ -370,7 +370,7 @@ USB_DMX_DLL DWORD SetInterfaceAdvTxConfig(
     buffer[10] = (Interframetime >> 8) & 255;
     buffer[11] = Channelcount & 255;
     buffer[12] = (Channelcount >> 8) & 255;
-    buffer[13] = Startbyte;
+    buffer[13] = (unsigned char)Startbyte;
 
     hid_write(open_devices[pos].handle, buffer, 34);
 

--- a/windows/hid.c
+++ b/windows/hid.c
@@ -620,7 +620,7 @@ int HID_API_EXPORT HID_API_CALL hid_write(hid_device *dev, const unsigned char *
 		length = dev->output_report_length;
 	}
 
-	res = WriteFile(dev->device_handle, buf, length, NULL, &ol);
+	res = WriteFile(dev->device_handle, buf, (DWORD)length, NULL, &ol);
 	
 	if (!res) {
 		if (GetLastError() != ERROR_IO_PENDING) {
@@ -662,7 +662,7 @@ int HID_API_EXPORT HID_API_CALL hid_read_timeout(hid_device *dev, unsigned char 
 		dev->read_pending = TRUE;
 		memset(dev->read_buf, 0, dev->input_report_length);
 		ResetEvent(ev);
-		res = ReadFile(dev->device_handle, dev->read_buf, dev->input_report_length, &bytes_read, &dev->ol);
+		res = ReadFile(dev->device_handle, dev->read_buf, (DWORD)dev->input_report_length, &bytes_read, &dev->ol);
 		
 		if (!res) {
 			if (GetLastError() != ERROR_IO_PENDING) {
@@ -733,13 +733,13 @@ int HID_API_EXPORT HID_API_CALL hid_set_nonblocking(hid_device *dev, int nonbloc
 
 int HID_API_EXPORT HID_API_CALL hid_send_feature_report(hid_device *dev, const unsigned char *data, size_t length)
 {
-	BOOL res = HidD_SetFeature(dev->device_handle, (PVOID)data, length);
+	BOOL res = HidD_SetFeature(dev->device_handle, (PVOID)data, (DWORD)length);
 	if (!res) {
 		register_error(dev, "HidD_SetFeature");
 		return -1;
 	}
 
-	return length;
+	return (int)length;
 }
 
 
@@ -761,8 +761,8 @@ int HID_API_EXPORT HID_API_CALL hid_get_feature_report(hid_device *dev, unsigned
 
 	res = DeviceIoControl(dev->device_handle,
 		IOCTL_HID_GET_FEATURE,
-		data, length,
-		data, length,
+		data, (DWORD)length,
+		data, (DWORD)length,
 		&bytes_returned, &ol);
 
 	if (!res) {
@@ -797,7 +797,7 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_manufacturer_string(hid_device *dev
 {
 	BOOL res;
 
-	res = HidD_GetManufacturerString(dev->device_handle, string, sizeof(wchar_t) * maxlen);
+	res = HidD_GetManufacturerString(dev->device_handle, string, sizeof(wchar_t) * (ULONG)maxlen);
 	if (!res) {
 		register_error(dev, "HidD_GetManufacturerString");
 		return -1;
@@ -810,7 +810,7 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_product_string(hid_device *dev, wch
 {
 	BOOL res;
 
-	res = HidD_GetProductString(dev->device_handle, string, sizeof(wchar_t) * maxlen);
+	res = HidD_GetProductString(dev->device_handle, string, sizeof(wchar_t) * (ULONG)maxlen);
 	if (!res) {
 		register_error(dev, "HidD_GetProductString");
 		return -1;
@@ -823,7 +823,7 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_serial_number_string(hid_device *de
 {
 	BOOL res;
 
-	res = HidD_GetSerialNumberString(dev->device_handle, string, sizeof(wchar_t) * maxlen);
+	res = HidD_GetSerialNumberString(dev->device_handle, string, sizeof(wchar_t) * (ULONG)maxlen);
 	if (!res) {
 		register_error(dev, "HidD_GetSerialNumberString");
 		return -1;
@@ -836,7 +836,7 @@ int HID_API_EXPORT_CALL HID_API_CALL hid_get_indexed_string(hid_device *dev, int
 {
 	BOOL res;
 
-	res = HidD_GetIndexedString(dev->device_handle, string_index, string, sizeof(wchar_t) * maxlen);
+	res = HidD_GetIndexedString(dev->device_handle, string_index, string, sizeof(wchar_t) * (ULONG)maxlen);
 	if (!res) {
 		register_error(dev, "HidD_GetIndexedString");
 		return -1;


### PR DESCRIPTION
- size_t in 64 bit systems is 64 bit, so the hid_XXX functions that use
  size_t but call system functions HidD_XXX give a warning of possible
  loss of data when converting size_t to DWORD. Where appropriate these
  conversions have been added explicitly to silence the warnings.

- In wserial_to_serial the pseudo conversion from wchar_t to char gives
  a warning. The simplified convertion is legitimite only in cases where
  the wchar_t is a ascii character, which should be the case here.

- In SetInterfaceAdvTxConfig Startbyte is passed as uint16_t but the
  assignment to the assignment to the buffer is done as unsigned char,
  giving a warning. Here a conversion is applied although the better
  solution would be to pass the startbyte as unsigned char in the first
  place. But that would break the historic interface declaration.